### PR TITLE
fix: Use browser date input in `DateField`

### DIFF
--- a/src/components/DateField.svelte
+++ b/src/components/DateField.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { createDateField } from "@melt-ui/svelte";
-
 	type Props = {
 		onChange?: (year: number,month: number,day: number) => void
 	}
@@ -9,12 +7,11 @@
     // The date is always parsed as YYYY-MM-DD regardless of the locale.
     let selectedDate: string | undefined= $state(undefined);
 
-
     $effect(()=>{
         if (!selectedDate) return;
         let [year,month,day] = selectedDate.split("-").map(d => parseInt(d));
         onChange?.(year,month,day);
-    })
+    });
 </script>
 
 <label class="flex h-full w-full flex-col gap-1">
@@ -29,12 +26,18 @@
 		border: 1px solid var(--color-neutral-50);
 		padding: 8px 12px;
 		border-radius: var(--radius-sm);
+        outline: none;
+        transition: all 150ms;
+
+        &:focus{
+            border-color: var(--color-purple-500);
+        }
 	}
 
     /* Hide default calendar button */
     input[type="date"]::-webkit-inner-spin-button,
     input[type="date"]::-webkit-calendar-picker-indicator {
         display: none;
-        -webkit-appearance: none;
+        appearance: none;
     }
 </style>

--- a/src/components/DatePicker.svelte
+++ b/src/components/DatePicker.svelte
@@ -35,7 +35,7 @@
 	<i class="ph ph-calendar"></i>
 </button>
 {#if $open}
-	<div transition:scale={{ start:0.8 }} {...$content} use:content>
+	<div transition:scale={{ start:0.8 }} {...$content} use:content class="absolute z-100">
 	    <div {...$calendar} use:calendar>
 		<header class="calendar-header">
             <button class="icon-btn icon-btn-medium icon-btn-primary" {...$prevButton} use:prevButton>


### PR DESCRIPTION
## Changes
Use the browser date input instead of the melt-ui `DateField` component.